### PR TITLE
Require mkfs before allowing fs commands

### DIFF
--- a/src/device_nvme.c
+++ b/src/device_nvme.c
@@ -174,5 +174,5 @@ void dflush(struct device *dev) {
 }
 
 void dclose(struct device *dev) {
-
+  cleanup();
 }


### PR DESCRIPTION
Hey Leo -

I think these changes should fix the problem I was having where `spdk_nvme_probe()` would hang if I tried to run a command (like `ls`) before a file system was created.

These changes add:
1. A way to check if a file system exists
2. A whitelist of commands that can be run if the file system does not exist
3. Code that detaches SPDK from the NVMe controller on shutdown

In a nutshell I think the problem I had was caused by something in SPDK leaving the device in an invalid state when `testFS` crashed. So I made sure that we detach SPDK properly when exiting and also added some logic to prevent file system commands from being executed before a file system exists. The problem may still occur if the filesystem crashes due to an assertion failure. To recover, I found that rebooting the VM was enough (at least on a Linux host machine).

To determine if a file system exists, I think we can just get away with checking the inode type of the current directory's inode. If the file system is valid, the inode's type should be `I_DIR`. If the file system is invalid, it's unlikely for the inode to have a type of `I_DIR` (unless whatever is on the device at the correct block number somehow maps to the correct enum value for `I_DIR`, which I think we can assume is unlikely for our purposes).

Please take a look and let me know what you think!